### PR TITLE
Fixed compiled javascript syntax errors in IE11

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,13 @@
 {
 	"compilerOptions": {
-		"target": "esnext",
+		"target": "es5",
 		"module": "commonjs",
 		"outDir": "dist",
 		"declarationDir": "dist/typings",
 		"noImplicitAny": false,
 		"sourceMap": true,
-		"declaration": true
+		"declaration": true,
+		"lib": ["esnext"]
 	},
 	"exclude": [
 		"node_modules",


### PR DESCRIPTION
I'm currently using [codemirror-textmate](https://github.com/NeekSandhu/codemirror-textmate) in an Angular project which I would like to support IE11, but the compiled JavaScript for this package (which is a dependency of codemirror-textmate) currently breaks the app in IE11 because it includes arrow functions. Changing the target to `es5` and moving `esnext` to `lib` in the tsconfig `compilerOptions` fixes this problem.

Note that this issue occurs even though I'm loading the default CodeMirror modes instead of the TM grammars for IE11 (because no WASM in IE11) because Angular concatenates all JS dependencies into a single file. I haven't yet explored using code splitting to avoid loading this dependency entirely if it's not needed, but I'm not sure if that's possible with the way [lazy-loading](https://angular.io/guide/lazy-loading-ngmodules) works in Angular.