### PR TITLE
Removes the dependency on Node "path" module

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
   "devDependencies": {
     "@types/node": "^10.0.4",
     "tslint": "^3.15.1",
-    "typescript": "^2.0.8"
+    "typescript": "^5.3.3"
   }
 }

--- a/src/rule.ts
+++ b/src/rule.ts
@@ -2,8 +2,7 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
-import * as path from 'path';
-import { RegexSource, mergeObjects } from './utils';
+import { RegexSource, basename, mergeObjects } from './utils';
 import { ILocation, IRawGrammar, IRawRepository, IRawRule, IRawCaptures } from './types';
 import { OnigString, OnigScanner, IOnigCaptureIndex } from 'onigasm';
 
@@ -49,7 +48,7 @@ export abstract class Rule {
 	}
 
 	public get debugName(): string {
-		return `${(<any>this.constructor).name}#${this.id} @ ${path.basename(this.$location.filename)}:${this.$location.line}`;
+		return `${(<any>this.constructor).name}#${this.id} @ ${basename(this.$location.filename)}:${this.$location.line}`;
 	}
 
 	public getName(lineText: string, captureIndices: IOnigCaptureIndex[]): string {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -43,6 +43,17 @@ export function mergeObjects(target: any, ...sources: any[]): any {
 	return target;
 }
 
+export function basename(path: string): string {
+	const idx = ~path.lastIndexOf('/') || ~path.lastIndexOf('\\');
+	if (idx === 0) {
+		return path;
+	} else if (~idx === path.length - 1) {
+		return basename(path.substring(0, path.length - 1));
+	} else {
+		return path.substr(~idx + 1);
+	}
+}
+
 let CAPTURING_REGEX_SOURCE = /\$(\d+)|\${(\d+):\/(downcase|upcase)}/;
 
 export class RegexSource {


### PR DESCRIPTION
Removes the dependency on Node "path" module with a function to retrieve the basepath.

New `basepath` function has been lifted from here:

https://github.com/microsoft/vscode-textmate/blob/09effd8b7429b71010e0fa34ea2e16e622692946/src/utils.ts#L46-L55

I also had to update TypeScript dependency to fix the broken build.

Fixes #11